### PR TITLE
fix issue #38

### DIFF
--- a/libraries/SD/src/utility/Sd2Card.cpp
+++ b/libraries/SD/src/utility/Sd2Card.cpp
@@ -252,18 +252,9 @@ uint8_t Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   uint32_t arg;
 
   // set pin modes
-//#ifdef BOARD_SIPEED_MAIXDUINO
-  int gpionum = get_gpio(chipSelectPin_);
-    if(gpionum >= 0){
-        fpioa_function_t function = fpioa_function_t(FUNC_GPIOHS0 + gpionum);
-        fpioa_set_function(chipSelectPin_, function);
-        gpiohs_set_drive_mode((uint8_t)gpionum, GPIO_DM_OUTPUT);
-         gpiohs_set_pin((uint8_t)gpionum, GPIO_PV_HIGH);
-    }
-//#else
-//  pinMode(chipSelectPin_, OUTPUT);
-//  digitalWrite(chipSelectPin_, HIGH);
-//#endif
+  pinMode(chipSelectPin_, OUTPUT);
+  digitalWrite(chipSelectPin_, HIGH);
+
 #ifndef USE_SPI_LIB
   pinMode(SPI_MISO_PIN, INPUT);
   pinMode(SPI_MOSI_PIN, OUTPUT);

--- a/variants/sipeed_maixduino/pins_arduino.h
+++ b/variants/sipeed_maixduino/pins_arduino.h
@@ -71,7 +71,7 @@ typedef struct _pwm_fpio_set_t{
     uint8_t inuse;
 }pwm_fpio_set_t;
 
-#define MD_PIN_MAP(fpio) _maixduino_pin_map[(fpio)]
+#define MD_PIN_MAP(fpio) (((fpio) < 17) ? _maixduino_pin_map[(fpio)] : (fpio))
 
 static const uint8_t _maixduino_pin_map[17] = {4, 5, 21, 22, 23, 24, 32, 15, 14, 13, 12, 11, 10, 3, 31, 30, 16};
 


### PR DESCRIPTION
SD2Card code use low level api to init SPI select pin, but it uses Arduino High level api to write. 
Then it sill cause gpio index error.  #38 