### PR TITLE
Fix module path for non-windows OS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,6 @@
 [submodule "libraries/lv_arduino"]
 	path = libraries/lv_arduino
 	url = https://github.com/btx000/lv_arduino.git
-[submodule "libraries\\lv_maixduino"]
-	path = libraries\\lv_maixduino
+[submodule "libraries/lv_maixduino"]
+	path = libraries/lv_maixduino
 	url = https://github.com/littlevgl/lv_maixduino.git


### PR DESCRIPTION
`/` is the universal path separator. `\` is specific to Windows. Other OSes don't understand `\`