### PR TITLE
Use MIC RIGHT channel on Maix Bit-MIC board.

### DIFF
--- a/libraries/Maix_Speech_Recognition/src/Maix_Speech_Recognition.cpp
+++ b/libraries/Maix_Speech_Recognition/src/Maix_Speech_Recognition.cpp
@@ -56,7 +56,7 @@ int i2s_dma_irq(void *ctx)
             for(i = 0; i < frame_mov; i++)
             {
 #ifdef _VARIANT_SIPEED_MAIX_BIT_MIC
-                s_tmp = (int16_t)((g_rx_dma_buf[2 * i] >> 16) & 0xffff); //g_rx_dma_buf[2 * i + 1] High right
+                s_tmp = (int16_t)(g_rx_dma_buf[2 * i + 1] & 0xffff); // High right
 #else
                 s_tmp = (int16_t)(g_rx_dma_buf[2 * i] & 0xffff); //g_rx_dma_buf[2 * i + 1] Low left
 #endif
@@ -71,7 +71,7 @@ int i2s_dma_irq(void *ctx)
             for(i = frame_mov; i < frame_mov * 2; i++)
             {
 #ifdef _VARIANT_SIPEED_MAIX_BIT_MIC
-                s_tmp = (int16_t)((g_rx_dma_buf[2 * i] >> 16) & 0xffff); //g_rx_dma_buf[2 * i + 1] High right
+                s_tmp = (int16_t)(g_rx_dma_buf[2 * i + 1] & 0xffff); // High right
 #else
                 s_tmp = (int16_t)(g_rx_dma_buf[2 * i] & 0xffff);//g_rx_dma_buf[2 * i + 1] Low left
 #endif

--- a/libraries/Maix_Speech_Recognition/src/Maix_Speech_Recognition.cpp
+++ b/libraries/Maix_Speech_Recognition/src/Maix_Speech_Recognition.cpp
@@ -55,7 +55,11 @@ int i2s_dma_irq(void *ctx)
             g_index = 0;
             for(i = 0; i < frame_mov; i++)
             {
+#ifdef _VARIANT_SIPEED_MAIX_BIT_MIC
+                s_tmp = (int16_t)((g_rx_dma_buf[2 * i] >> 16) & 0xffff); //g_rx_dma_buf[2 * i + 1] High right
+#else
                 s_tmp = (int16_t)(g_rx_dma_buf[2 * i] & 0xffff); //g_rx_dma_buf[2 * i + 1] Low left
+#endif
                 rx_buf[i] = s_tmp + 32768;
             }
             i2s_rec_flag = 1;
@@ -66,7 +70,11 @@ int i2s_dma_irq(void *ctx)
             g_index = frame_mov * 2;
             for(i = frame_mov; i < frame_mov * 2; i++)
             {
+#ifdef _VARIANT_SIPEED_MAIX_BIT_MIC
+                s_tmp = (int16_t)((g_rx_dma_buf[2 * i] >> 16) & 0xffff); //g_rx_dma_buf[2 * i + 1] High right
+#else
                 s_tmp = (int16_t)(g_rx_dma_buf[2 * i] & 0xffff);//g_rx_dma_buf[2 * i + 1] Low left
+#endif
                 rx_buf[i] = s_tmp + 32768;
             }
             i2s_rec_flag = 2;


### PR DESCRIPTION
Due to changes in the microphone circuit (LR pin) the speech recognition library doesn't work on new versions of MAIX Bit and probably MAIX Go. 
This PR only solve the problem with MAIX Bit-MIC.
It's necessary to check the course of action for Maix-Go V2 (new board/variant?).