### PR TITLE
Fixed receiving the NUL '\x00' character on Serial

### DIFF
--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -187,7 +187,7 @@ uarths_rec_callback(void *ctx)
   int data;
   auto &driver = *reinterpret_cast<UARTHSClass *>(ctx);
   data = uarths_getc();
-  if(data != 0){
+  if(data != EOF){
     driver._buff->store_char((char)data);
   }
   return 0;


### PR DESCRIPTION
The previous code was checking whether the `uarths_getc()` function returned 0 to check if no data was available on the serial interrupt.
However, `uarths_getc()` returns EOF if there is nothing to read, and EOF is defined in stdio.h to be -1.
This caused UARTClass to not be able to receive the 0 character.