### PR TITLE
Missing devices added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
 Maixduino
 ========
 
-Arduino core for Maix Board (K210)
+# Arduino Core for K210 based devices
 
+
+
+## Supported devices
+
+### Sipeed Maix series
+  - [Amigo](https://dl.sipeed.com/MAIX/HDK/Sipeed-Amigo)
+  - [Cube](https://dl.sipeed.com/MAIX/HDK/Sipeed-Maix-Cube)
+  - [Go](https://dl.sipeed.com/MAIX/HDK/Sipeed-Maix-GO)
+  - [Maixduino](https://dl.sipeed.com/MAIX/HDK/Sipeed-Maixduino)
+  - [Dock](https://dl.sipeed.com/MAIX/HDK/Sipeed-Maix-Dock)
+  - [BiT](https://dl.sipeed.com/MAIX/HDK/Sipeed-Maix-Bit)
+  - [Nano](https://dl.sipeed.com/MAIX/HDK/Sipeed-Maix-Nano)
+
+### M5Stack
+ * [M5StickV](https://m5stack.com/products/stickv)
+ * [M5UnitV](https://m5stack.com/collections/m5-unit/products/unitv-ai-camera)
+
+### Various custom boards
+ * [LAMLOEI AOIT DAAN](https://github.com/lamloei/AIoTDaaN/tree/master/hardware/20190505-R2/AIoTDaaN_R2/pdf)
+ * [IOXGD4](https://github.com/ioxgd/IOXGD-hardware/tree/master/IOXGD4/pdf)
 
 ## Docs
 
@@ -12,10 +32,45 @@ Docs: [maixduino.sipeed.com](https://maixduino.sipeed.com/)
 
 Refer install doc: [Install](https://maixduino.sipeed.com/en/get_started/install.html)
 
+## Installing
 
-## Other SDK
+### From Board Manager
 
-If you want to code by scripts, refer to our [MaixPy](https://maixpy.sipeed.com)
+ 1. [Download and install the Arduino IDE](https://www.arduino.cc/en/Main/Software) (at least version v1.9.8)
+ 2. Start the Arduino IDE
+ 3. Go into Preferences
+ 4. Add ```https://github.com/UT2UH/Maixduino/blob/gh-pages/package_Maixduino_boards_index.json``` as an "Additional Board Manager URL"
+ 5. Open the Boards Manager from the Tools -> Board menu and install "Maixduino(K210)"
+ 6. Select your K210 board from the Tools -> Board menu
+
+### From git
+
+ 1. Follow steps from Board Manager section above
+ 2. ```cd <SKETCHBOOK>```, where ```<SKETCHBOOK>``` is your Arduino Sketch folder:
+  * OS X: ```~/Documents/Arduino```
+  * Linux: ```~/Arduino```
+  * Windows: ```~/Documents/Arduino```
+ 3. Create a folder named ```hardware```, if it does not exist, and change directories to it
+ 4. Clone this repo: ```git clone https://github.com/UT2UH/Maixduino/tree/MAixCore Maixduino/k210```
+ 5. Restart the Arduino IDE
+
+### Firmware flashing
+The firmware of the K210 devices is updated with a Python-based [kflash](https://github.com/sipeed/kflash.py) cross-platform tool.
+Follow ```kflash``` github page on installation instruction.
+
+
+###### Change board settings in Tools section on the top of Arduino IDE
+
+ 1. Board: The same as your dev board
+ 2. Burn Toolfirmware: leave default, for Maix Go Kit - ```open-ec```
+ 3. Burn Baudrate: Decrease it if download fails
+ 4. Port: Serial port, e.g. ```/dev/ttyUSB0```
+ 5. Programmer: ```k-flash```
+
+## Credits
+
+This core is based on and compatible with the [Sipeed Maixduino Core](https://github.com/sipeed/Maixduino)
+
 
 
 

--- a/boards.txt
+++ b/boards.txt
@@ -4,9 +4,242 @@ menu.burn_baudrate=Burn Baud Rate
 menu.toolsloc=Tool Install Location
 
 ##################################################
+############# Sipeed Maix Amigo ###############
+
+amigo.name=Sipeed Maix Amigo
+
+## Toolchain
+amigo.menu.toolsloc.default=Default
+amigo.menu.toolsloc.default.compiler.path={runtime.tools.riscv64-unknown-elf-gcc.path}/bin/
+
+## CPU Clock
+amigo.menu.clksrc.400=400MHz CPU Clock Frequency
+amigo.menu.clksrc.500=500MHz CPU Clock Frequency
+amigo.menu.clksrc.600=600MHz CPU Clock Frequency
+amigo.menu.clksrc.400.build.f_cpu=400000000L
+amigo.menu.clksrc.500.build.f_cpu=500000000L
+amigo.menu.clksrc.600.build.f_cpu=600000000L
+
+## Burn baud rate
+amigo.menu.burn_baudrate.2000000=2 Mbps
+amigo.menu.burn_baudrate.4500000=4.5 Mbps (Must open-ec!)
+amigo.menu.burn_baudrate.1500000=1.5 Mbps
+amigo.menu.burn_baudrate.1000000=1 Mbps
+amigo.menu.burn_baudrate.2000000.build.burn_baudrate=2000000
+amigo.menu.burn_baudrate.4500000.build.burn_baudrate=4500000
+amigo.menu.burn_baudrate.1500000.build.burn_baudrate=1500000
+amigo.menu.burn_baudrate.1000000.build.burn_baudrate=1000000
+
+## Burn tool firmware
+amigo.menu.burn_tool_firmware.amigo=open-ec
+amigo.menu.burn_tool_firmware.amigo.build.burn_tool_firmware=goE
+
+## Core settings
+amigo.build.variant=sipeed_maix_amigo
+amigo.build.core=arduino
+
+## This sets a define for use in the compiled code.
+amigo.build.board=MAIX_AMIGO
+
+## This selects the tool from "programmers.txt"
+amigo.program.tool=kflash
+amigo.upload.tool=kflash
+
+## Limit is the 16MB Flash. Assume half is used for something else.
+amigo.upload.maximum_size=8388608
+amigo.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
+
+##################################################
+############# Sipeed Maix Cube ###############
+
+cube.name=Sipeed Maix Cube
+
+## Toolchain
+cube.menu.toolsloc.default=Default
+cube.menu.toolsloc.default.compiler.path={runtime.tools.riscv64-unknown-elf-gcc.path}/bin/
+
+## CPU Clock
+cube.menu.clksrc.400=400MHz CPU Clock Frequency
+cube.menu.clksrc.500=500MHz CPU Clock Frequency
+cube.menu.clksrc.600=600MHz CPU Clock Frequency
+cube.menu.clksrc.400.build.f_cpu=400000000L
+cube.menu.clksrc.500.build.f_cpu=500000000L
+cube.menu.clksrc.600.build.f_cpu=600000000L
+
+## Burn baud rate
+cube.menu.burn_baudrate.1500000=1.5 Mbps
+cube.menu.burn_baudrate.1000000=1 Mbps
+cube.menu.burn_baudrate.1500000.build.burn_baudrate=1500000
+cube.menu.burn_baudrate.1000000.build.burn_baudrate=1000000
+
+## Burn tool firmware
+cube.menu.burn_tool_firmware.cube=open-ec
+cube.menu.burn_tool_firmware.cube.build.burn_tool_firmware=goE
+
+## Point to the file for ./variants/<variant>/pins_arduino.h
+cube.build.variant=sipeed_maix_cube
+
+## "The 'core' file directory for this board, in ./cores
+cube.build.core=arduino
+
+## This sets a define for use in the compiled code.
+cube.build.board=MAIX_CUBE
+cube.build.sdata.size=512
+
+## This selects the tool from "programmers.txt"
+cube.upload.tool=kflash
+
+## Limit is the 16MB Flash. Assume half is used for something else.
+cube.upload.maximum_size=8388608
+cube.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
+
+####################################################
+############### Sipeed Maix Go Board ###############
+
+go.name=Sipeed Maix Go
+
+## Toolchain
+go.menu.toolsloc.default=Default
+go.menu.toolsloc.default.compiler.path={runtime.tools.riscv64-unknown-elf-gcc.path}/bin/
+
+## CPU Clock
+go.menu.clksrc.400=400MHz CPU Clock Frequency
+go.menu.clksrc.500=500MHz CPU Clock Frequency
+go.menu.clksrc.600=600MHz CPU Clock Frequency
+go.menu.clksrc.400.build.f_cpu=400000000L
+go.menu.clksrc.500.build.f_cpu=500000000L
+go.menu.clksrc.600.build.f_cpu=600000000L
+
+## Burn baud rate
+go.menu.burn_baudrate.2000000=2 Mbps
+go.menu.burn_baudrate.4500000=4.5 Mbps (Must open-ec!)
+go.menu.burn_baudrate.1500000=1.5 Mbps
+go.menu.burn_baudrate.1000000=1 Mbps
+go.menu.burn_baudrate.2000000.build.burn_baudrate=2000000
+go.menu.burn_baudrate.4500000.build.burn_baudrate=4500000
+go.menu.burn_baudrate.1500000.build.burn_baudrate=1500000
+go.menu.burn_baudrate.1000000.build.burn_baudrate=1000000
+
+## Burn tool firmware
+go.menu.burn_tool_firmware.goE=open-ec
+go.menu.burn_tool_firmware.goD=CMSIS-DAP
+go.menu.burn_tool_firmware.goE.build.burn_tool_firmware=goE
+go.menu.burn_tool_firmware.goD.build.burn_tool_firmware=goD
+
+## Core settings
+## Point to the file for ./variants/<variant>/pins_arduino.h
+go.build.variant=sipeed_maix_go
+
+## "The 'core' file directory for this board, in ./cores
+go.build.core=arduino
+
+## This sets a define for use in the compiled code.
+go.build.board=MAIX_GO
+
+## This selects the tool from "programmers.txt"
+go.program.tool=kflash
+go.upload.tool=kflash
+
+## Limit is the 16MB Flash. Assume half is used for something else.
+go.upload.maximum_size=8388608
+go.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
+
+##################################################
+############# Sipeed Maixduino Board ###############
+
+mduino.name=Sipeed Maixduino
+
+## Toolchain
+mduino.menu.toolsloc.default=Default
+mduino.menu.toolsloc.default.compiler.path={runtime.tools.riscv64-unknown-elf-gcc.path}/bin/
+
+## CPU Clock
+mduino.menu.clksrc.400=400MHz CPU Clock Frequency
+mduino.menu.clksrc.500=500MHz CPU Clock Frequency
+mduino.menu.clksrc.600=600MHz CPU Clock Frequency
+mduino.menu.clksrc.400.build.f_cpu=400000000L
+mduino.menu.clksrc.500.build.f_cpu=500000000L
+mduino.menu.clksrc.600.build.f_cpu=600000000L
+
+## Burn baud rate
+mduino.menu.burn_baudrate.1500000=1.5 Mbps
+mduino.menu.burn_baudrate.1000000=1 Mbps
+mduino.menu.burn_baudrate.1500000.build.burn_baudrate=1500000
+mduino.menu.burn_baudrate.1000000.build.burn_baudrate=1000000
+
+## Burn tool firmware
+mduino.menu.burn_tool_firmware.mduino=Default
+mduino.menu.burn_tool_firmware.mduino.build.burn_tool_firmware=maixduino
+
+## Point to the file for ./variants/<variant>/pins_arduino.h
+mduino.build.variant=sipeed_maixduino
+
+## "The 'core' file directory for this board, in ./cores
+mduino.build.core=arduino
+
+## This sets a define for use in the compiled code.
+mduino.build.board=MAIX_DUINO
+mduino.build.sdata.size=512
+
+## This selects the tool from "programmers.txt"
+mduino.program.tool=kflash
+mduino.upload.tool=kflash
+
+## Limit is the 16MB Flash. Assume half is used for something else.
+mduino.upload.maximum_size=8388608
+mduino.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
+
+##################################################
+############# Sipeed M1W Dock Board ###############
+
+m1w.name=Sipeed Maix Dock M1W
+
+## Toolchain
+m1w.menu.toolsloc.default=Default
+m1w.menu.toolsloc.default.compiler.path={runtime.tools.riscv64-unknown-elf-gcc.path}/bin/
+
+## CPU Clock
+m1w.menu.clksrc.400=400MHz CPU Clock Frequency
+m1w.menu.clksrc.500=500MHz CPU Clock Frequency
+m1w.menu.clksrc.600=600MHz CPU Clock Frequency
+m1w.menu.clksrc.400.build.f_cpu=400000000L
+m1w.menu.clksrc.500.build.f_cpu=500000000L
+m1w.menu.clksrc.600.build.f_cpu=600000000L
+
+## Burn baud rate
+m1w.menu.burn_baudrate.2000000=2 Mbps
+m1w.menu.burn_baudrate.1500000=1.5 Mbps
+m1w.menu.burn_baudrate.1000000=1 Mbps
+m1w.menu.burn_baudrate.2000000.build.burn_baudrate=2000000
+m1w.menu.burn_baudrate.1500000.build.burn_baudrate=1500000
+m1w.menu.burn_baudrate.1000000.build.burn_baudrate=1000000
+
+## Burn tool firmware
+m1w.menu.burn_tool_firmware.dan=Default
+m1w.menu.burn_tool_firmware.dan.build.burn_tool_firmware=dan
+
+## Point to the file for ./variants/<variant>/pins_arduino.h
+m1w.build.variant=sipeed_maix_one_w_dock
+
+## "The 'core' file directory for this board, in ./cores
+m1w.build.core=arduino
+
+## This sets a define for use in the compiled code.
+m1w.build.board=MAIX_DOCK_M1W
+m1w.build.sdata.size=512
+
+## This selects the tool from "programmers.txt"
+m1w.program.tool=kflash
+m1w.upload.tool=kflash
+
+## Limit is the 16MB Flash. Assume half is used for something else.
+m1w.upload.maximum_size=8388608
+m1w.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
+
+##################################################
 ############# Sipeed M1 Dock Board ###############
 
-m1.name=Sipeed Maix One Dock Board
+m1.name=Sipeed Maix Dock M1
 
 ## Toolchain
 m1.menu.toolsloc.default=Default
@@ -39,7 +272,7 @@ m1.build.variant=sipeed_maix_one_dock
 m1.build.core=arduino
 
 ## This sets a define for use in the compiled code.
-m1.build.board=BOARD_SIPEED_MAIX_ONE_DOCK
+m1.build.board=MAIX_DOCK_M1
 m1.build.sdata.size=512
 
 ## This selects the tool from "programmers.txt"
@@ -53,7 +286,7 @@ m1.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk
 ##################################################
 ############# Sipeed Maix Bit Board ###############
 
-bit.name=Sipeed Maix Bit Board
+bit.name=Sipeed Maix Bit
 
 ## Toolchain
 bit.menu.toolsloc.default=Default
@@ -86,7 +319,7 @@ bit.build.variant=sipeed_maix_bit
 bit.build.core=arduino
 
 ## This sets a define for use in the compiled code.
-bit.build.board=BOARD_SIPEED_MAIX_BIT
+bit.build.board=MAIX_BIT
 bit.build.sdata.size=512
 
 ## This selects the tool from "programmers.txt"
@@ -101,7 +334,7 @@ bit.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sd
 ##################################################
 ############# Sipeed Maix Bit with Mic Board ###############
 
-bitm.name=Sipeed Maix Bit-Mic Board
+bitm.name=Sipeed Maix Bit-Mic
 
 ## Toolchain
 bitm.menu.toolsloc.default=Default
@@ -132,7 +365,7 @@ bitm.build.variant=sipeed_maix_bit_mic
 bitm.build.core=arduino
 
 ## This sets a define for use in the compiled code.
-bitm.build.board=BOARD_SIPEED_MAIX_BIT
+bitm.build.board=MAIX_BIT_M
 bitm.build.sdata.size=512
 
 ## This selects the tool from "programmers.txt"
@@ -142,106 +375,101 @@ bitm.upload.tool=kflash
 bitm.upload.maximum_size=8388608
 bitm.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
 
-
-
-####################################################
-############### Sipeed Maix Go Board ###############
-
-go.name=Sipeed Maix Go Board
-
-
-## Toolchain
-go.menu.toolsloc.default=Default
-go.menu.toolsloc.default.compiler.path={runtime.tools.riscv64-unknown-elf-gcc.path}/bin/
-
-## CPU Clock
-go.menu.clksrc.400=400MHz CPU Clock Frequency
-go.menu.clksrc.500=500MHz CPU Clock Frequency
-go.menu.clksrc.600=600MHz CPU Clock Frequency
-go.menu.clksrc.400.build.f_cpu=400000000L
-go.menu.clksrc.500.build.f_cpu=500000000L
-go.menu.clksrc.600.build.f_cpu=600000000L
-
-## Burn baud rate
-go.menu.burn_baudrate.2000000=2 Mbps
-go.menu.burn_baudrate.4500000=4.5 Mbps (Must open-ec!)
-go.menu.burn_baudrate.1500000=1.5 Mbps
-go.menu.burn_baudrate.1000000=1 Mbps
-go.menu.burn_baudrate.2000000.build.burn_baudrate=2000000
-go.menu.burn_baudrate.4500000.build.burn_baudrate=4500000
-go.menu.burn_baudrate.1500000.build.burn_baudrate=1500000
-go.menu.burn_baudrate.1000000.build.burn_baudrate=1000000
-
-## Burn tool firmware
-go.menu.burn_tool_firmware.goE=open-ec
-go.menu.burn_tool_firmware.goD=CMSIS-DAP
-go.menu.burn_tool_firmware.goE.build.burn_tool_firmware=goE
-go.menu.burn_tool_firmware.goD.build.burn_tool_firmware=goD
-
-## Core settings
-go.build.variant=sipeed_maix_go
-go.build.core=arduino
-
-## This sets a define for use in the compiled code.
-go.build.board=BOARD_SIPEED_MAIX_GO
-
-## This selects the tool from "programmers.txt"
-go.program.tool=kflash
-go.upload.tool=kflash
-
-## Limit is the 16MB Flash. Assume half is used for something else.
-go.upload.maximum_size=8388608
-go.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
-
 ##################################################
-############# Sipeed Maixduino Board ###############
+############# M5Stack M5StickV Stick ###############
 
-mduino.name=Sipeed Maixduino Board
+stickv.name=M5Stack M5StickV Stick
 
 ## Toolchain
-mduino.menu.toolsloc.default=Default
-mduino.menu.toolsloc.default.compiler.path={runtime.tools.riscv64-unknown-elf-gcc.path}/bin/
+stickv.menu.toolsloc.default=Default
+stickv.menu.toolsloc.default.compiler.path={runtime.tools.riscv64-unknown-elf-gcc.path}/bin/
 
 ## CPU Clock
-mduino.menu.clksrc.400=400MHz CPU Clock Frequency
-mduino.menu.clksrc.500=500MHz CPU Clock Frequency
-mduino.menu.clksrc.600=600MHz CPU Clock Frequency
-mduino.menu.clksrc.400.build.f_cpu=400000000L
-mduino.menu.clksrc.500.build.f_cpu=500000000L
-mduino.menu.clksrc.600.build.f_cpu=600000000L
+stickv.menu.clksrc.400=400MHz CPU Clock Frequency
+stickv.menu.clksrc.500=500MHz CPU Clock Frequency
+stickv.menu.clksrc.600=600MHz CPU Clock Frequency
+stickv.menu.clksrc.400.build.f_cpu=400000000L
+stickv.menu.clksrc.500.build.f_cpu=500000000L
+stickv.menu.clksrc.600.build.f_cpu=600000000L
 
 ## Burn baud rate
-mduino.menu.burn_baudrate.1500000=1.5 Mbps
-mduino.menu.burn_baudrate.1000000=1 Mbps
-mduino.menu.burn_baudrate.1500000.build.burn_baudrate=1500000
-mduino.menu.burn_baudrate.1000000.build.burn_baudrate=1000000
+stickv.menu.burn_baudrate.1500000=1.5 Mbps
+stickv.menu.burn_baudrate.1000000=1 Mbps
+stickv.menu.burn_baudrate.1500000.build.burn_baudrate=1500000
+stickv.menu.burn_baudrate.1000000.build.burn_baudrate=1000000
 
 ## Burn tool firmware
-mduino.menu.burn_tool_firmware.mduino=Default
-mduino.menu.burn_tool_firmware.mduino.build.burn_tool_firmware=maixduino
+stickv.menu.burn_tool_firmware.stick1=CH340
+stickv.menu.burn_tool_firmware.stick1.build.burn_tool_firmware=bit-mic
+
 
 ## Point to the file for ./variants/<variant>/pins_arduino.h
-mduino.build.variant=sipeed_maixduino
+stickv.build.variant=m5stack_m5stick_v
 
 ## "The 'core' file directory for this board, in ./cores
-mduino.build.core=arduino
+stickv.build.core=arduino
 
 ## This sets a define for use in the compiled code.
-mduino.build.board=BOARD_SIPEED_MAIX_DUINO
-mduino.build.sdata.size=512
+stickv.build.board=M5STICK_V
+stickv.build.sdata.size=512
 
 ## This selects the tool from "programmers.txt"
-mduino.program.tool=kflash
-mduino.upload.tool=kflash
+stickv.program.tool=kflash
+stickv.upload.tool=kflash
 
 ## Limit is the 16MB Flash. Assume half is used for something else.
-mduino.upload.maximum_size=8388608
-mduino.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
+stickv.upload.maximum_size=8388608
+stickv.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
+
+##################################################
+############# M5Stack M5UnitV Camera ###############
+
+unitv.name=M5Stack M5UnitV Camera
+
+## Toolchain
+unitv.menu.toolsloc.default=Default
+unitv.menu.toolsloc.default.compiler.path={runtime.tools.riscv64-unknown-elf-gcc.path}/bin/
+
+## CPU Clock
+unitv.menu.clksrc.400=400MHz CPU Clock Frequency
+unitv.menu.clksrc.500=500MHz CPU Clock Frequency
+unitv.menu.clksrc.600=600MHz CPU Clock Frequency
+unitv.menu.clksrc.400.build.f_cpu=400000000L
+unitv.menu.clksrc.500.build.f_cpu=500000000L
+unitv.menu.clksrc.600.build.f_cpu=600000000L
+
+## Burn baud rate
+unitv.menu.burn_baudrate.1500000=1.5 Mbps
+unitv.menu.burn_baudrate.1000000=1 Mbps
+unitv.menu.burn_baudrate.1500000.build.burn_baudrate=1500000
+unitv.menu.burn_baudrate.1000000.build.burn_baudrate=1000000
+
+## Burn tool firmware
+unitv.menu.burn_tool_firmware.unit1=CH340
+unitv.menu.burn_tool_firmware.unit1.build.burn_tool_firmware=bit-mic
+
+## Point to the file for ./variants/<variant>/pins_arduino.h
+unitv.build.variant=m5stack_m5unit_v
+
+## "The 'core' file directory for this board, in ./cores
+unitv.build.core=arduino
+
+## This sets a define for use in the compiled code.
+unitv.build.board=M5UNIT_V
+unitv.build.sdata.size=512
+
+## This selects the tool from "programmers.txt"
+unitv.program.tool=kflash
+unitv.upload.tool=kflash
+
+## Limit is the 16MB Flash. Assume half is used for something else.
+unitv.upload.maximum_size=8388608
+unitv.build.ldscript="{runtime.platform.path}/cores/arduino/kendryte-standalone-sdk/lds/kendryte.ld"
 
 ##################################################
 ############# LamLoei AIoT DaaN Board ###############
 
-aiotdaan.name=LamLoei AIoT DaaN Board
+aiotdaan.name=LamLoei AIoT DaaN
 
 ## Toolchain
 aiotdaan.menu.toolsloc.default=Default
@@ -274,7 +502,7 @@ aiotdaan.build.variant=lamloei_aiot_daan
 aiotdaan.build.core=arduino
 
 ## This sets a define for use in the compiled code.
-aiotdaan.build.board=BOARD_SIPEED_MAIX_ONE_DOCK
+aiotdaan.build.board=MAIX_DOCK_M1
 aiotdaan.build.sdata.size=512
 
 ## This selects the tool from "programmers.txt"
@@ -321,7 +549,7 @@ ioxgd4.build.variant=ioxgd4
 ioxgd4.build.core=arduino
 
 ## This sets a define for use in the compiled code.
-ioxgd4.build.board=BOARD_SIPEED_MAIX_ONE_DOCK
+ioxgd4.build.board=MAIX_DOCK_M1
 ioxgd4.build.sdata.size=512
 
 ## This selects the tool from "programmers.txt"

--- a/cores/arduino/wiring_constants.h
+++ b/cores/arduino/wiring_constants.h
@@ -65,11 +65,11 @@ enum BitOrder {
 #endif // abs
 
 #ifndef min
-#define min(a,b) ((a)<(b)?(a):(b))
+#define min(a,b) (((a)<(b))?(a):(b))
 #endif // min
 
 #ifndef max
-#define max(a,b) ((a)>(b)?(a):(b))
+#define max(a,b) (((a)>(b))?(a):(b))
 #endif // max
 
 #define abs(x) ((x)>0?(x):-(x))

--- a/libraries/AXP173/AXP173.cpp
+++ b/libraries/AXP173/AXP173.cpp
@@ -1,0 +1,115 @@
+#include "AXP173.h"
+
+AXP173::AXP173()
+{
+  
+}
+
+void AXP173::begin(bool isInited)
+{
+    if(!isInited){
+        Wire.begin((uint8_t) SDA, (uint8_t) SCL, 400000);
+    }
+#if defined (ARDUINO_MAIX_AMIGO)
+    Write1Byte(0x27, 0x20); //LDO4 - 0.8V (default 0x48 1.8V)
+    Write1Byte(0x28, 0x0C); //LDO2/3 - LDO2 1.8V / LDO3 3.0V
+#else   //ARDUINO_MAIX_CUBE
+    Write1Byte(0x46, 0xFF); //Clear interupts
+    Write1Byte(0x33, 0xC1); //Set Bat Charging Voltage to 4V2, Current to 190mA
+    Write1Byte(0x10, (Read8bit(0x10) & 0xFC)); //EXTEN & DC-DC2 control
+#endif    
+}
+
+void AXP173::Write1Byte( uint8_t Addr ,  uint8_t Data )
+{
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.write(Data);
+    Wire.endTransmission();
+}
+
+uint8_t AXP173::Read8bit( uint8_t Addr )
+{
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 1);
+    return Wire.read();
+}
+
+uint16_t AXP173::Read12Bit( uint8_t Addr)
+{
+    uint16_t Data = 0;
+    uint8_t buf[2];
+    ReadBuff(Addr,2,buf);
+    Data = ((buf[0] << 4) + buf[1]);
+    return Data;
+}
+
+uint16_t AXP173::Read13Bit( uint8_t Addr)
+{
+    uint16_t Data = 0;
+    uint8_t buf[2];
+    ReadBuff(Addr,2,buf);
+    Data = ((buf[0] << 5) + buf[1]);
+    return Data;
+}
+
+uint16_t AXP173::Read16bit( uint8_t Addr )
+{
+    uint16_t ReData = 0;
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 2);
+    for( int i = 0 ; i < 2 ; i++ )
+    {
+        ReData <<= 8;
+        ReData |= Wire.read();
+    }
+    return ReData;
+}
+
+uint32_t AXP173::Read24bit( uint8_t Addr )
+{
+    uint32_t ReData = 0;
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 3);
+    for( int i = 0 ; i < 3 ; i++ )
+    {
+        ReData <<= 8;
+        ReData |= Wire.read();
+    }
+    return ReData;
+}
+
+uint32_t AXP173::Read32bit( uint8_t Addr )
+{
+    uint32_t ReData = 0;
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 4);
+    for( int i = 0 ; i < 4 ; i++ )
+    {
+        ReData <<= 8;
+        ReData |= Wire.read();
+    }
+    return ReData;
+}
+
+void AXP173::ReadBuff( uint8_t Addr , uint8_t Size , uint8_t *Buff )
+{
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, (int)Size);
+    for (int i = 0; i < Size; i++)
+    {
+        *( Buff + i )  = Wire.read();
+    }
+}
+
+

--- a/libraries/AXP173/AXP173.h
+++ b/libraries/AXP173/AXP173.h
@@ -1,0 +1,53 @@
+#ifndef __AXP173_H__
+#define __AXP173_H__
+
+#include <Wire.h>
+#include <Arduino.h>
+
+#define SLEEP_MSEC(us) (((uint64_t)us) * 1000L)
+#define SLEEP_SEC(us)  (((uint64_t)us) * 1000000L)
+#define SLEEP_MIN(us)  (((uint64_t)us) * 60L * 1000000L)
+#define SLEEP_HR(us)   (((uint64_t)us) * 60L * 60L * 1000000L)
+
+#define AXP_ADDR 0X34
+
+#define CURRENT_100MA  (0b0000)
+#define CURRENT_190MA  (0b0001)
+#define CURRENT_280MA  (0b0010)
+#define CURRENT_360MA  (0b0011)
+#define CURRENT_450MA  (0b0100)
+#define CURRENT_550MA  (0b0101)
+#define CURRENT_630MA  (0b0110)
+#define CURRENT_700MA  (0b0111)
+
+class AXP173 {
+public:
+
+    AXP173();
+    /**
+     * DCDC1: 3V3 Main rail. When not set the stick shuts down
+     * DCDC2: 0V9 K210 VCore
+     * DCDC3: 1V8 Use unknown
+     * LDO1: Don't set GPIO1 as LDO
+     * LDO2: 2V8 Display backlight
+     * LDO3: 1V5 Display Control
+     * GPIO0: LDO1 LCD_BL
+     * EXTEN:
+     */
+    void  begin(bool isInited = false);
+
+
+public:
+    
+private:
+    void Write1Byte( uint8_t Addr ,  uint8_t Data );
+    uint8_t Read8bit( uint8_t Addr );
+    uint16_t Read12Bit( uint8_t Addr);
+    uint16_t Read13Bit( uint8_t Addr);
+    uint16_t Read16bit( uint8_t Addr );
+    uint32_t Read24bit( uint8_t Addr );
+    uint32_t Read32bit( uint8_t Addr );
+    void ReadBuff( uint8_t Addr , uint8_t Size , uint8_t *Buff );
+}; 
+
+#endif

--- a/libraries/AXP192/AXP192.cpp
+++ b/libraries/AXP192/AXP192.cpp
@@ -1,0 +1,428 @@
+#include "AXP192.h"
+
+AXP192::AXP192()
+{
+  
+}
+
+void AXP192::begin(bool isInited)
+{
+    if(!isInited){
+        Wire.begin((uint8_t) SDA, (uint8_t) SCL, 400000);
+    }
+
+    Write1Byte(0x46, 0xFF); //Clear interupts
+    Write1Byte(0x23, 0x08); //Set DC-DC2 (VCore) to 0V9
+    Write1Byte(0x33, 0xC0); //Set Bat Charging Voltage to 4V2, Current to 100mA
+    Write1Byte(0x36, 0x0C); //Set 128ms power on, 4s power off
+    Write1Byte(0x91, 0xF0); //Set GPIO0 (TFT_BL) (from 0x70 (min)) to 3V3 (max)
+    Write1Byte(0x90, 0x02); //Set GPIO0 to LDO mode
+    Write1Byte(0x28, 0xF0); //VDD2.8V net: LDO2 3.3V,  VDD 1.5V net: LDO3 1.8V
+    Write1Byte(0x27, 0x2C); //VDD1.8V net: DC-DC3 1.8V
+    Write1Byte(0x12, 0xFF); //Enble all LDO/DC_DC and EXTEN
+    Write1Byte(0x23, 0x08); //VDD 0.9v net: DC-DC2 0.9V
+    Write1Byte(0x32, 0x46); //Enable bat detection
+    Write1Byte(0x39, 0xFC); //Disable Temp Protection (Sensor doesn't exist!)
+    Write1Byte(0x31, (Read8bit(0x31) & 0xf8) | (1 << 2)); // Set Power off voltage 3V0
+
+    fpioa_set_function(INTL_INT, (fpioa_function_t)(FUNC_GPIOHS0 + 26));
+    gpiohs_set_drive_mode(26, GPIO_DM_OUTPUT);
+    gpiohs_set_pin(26, GPIO_PV_HIGH); //Disable VBUS As Input, BAT->5V Boost->VBUS->Charing Cycle
+
+    msleep(20);
+}
+
+void AXP192::Write1Byte( uint8_t Addr ,  uint8_t Data )
+{
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.write(Data);
+    Wire.endTransmission();
+}
+
+uint8_t AXP192::Read8bit( uint8_t Addr )
+{
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 1);
+    return Wire.read();
+}
+
+uint16_t AXP192::Read12Bit( uint8_t Addr)
+{
+    uint16_t Data = 0;
+    uint8_t buf[2];
+    ReadBuff(Addr,2,buf);
+    Data = ((buf[0] << 4) + buf[1]);
+    return Data;
+}
+
+uint16_t AXP192::Read13Bit( uint8_t Addr)
+{
+    uint16_t Data = 0;
+    uint8_t buf[2];
+    ReadBuff(Addr,2,buf);
+    Data = ((buf[0] << 5) + buf[1]);
+    return Data;
+}
+
+uint16_t AXP192::Read16bit( uint8_t Addr )
+{
+    uint16_t ReData = 0;
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 2);
+    for( int i = 0 ; i < 2 ; i++ )
+    {
+        ReData <<= 8;
+        ReData |= Wire.read();
+    }
+    return ReData;
+}
+
+uint32_t AXP192::Read24bit( uint8_t Addr )
+{
+    uint32_t ReData = 0;
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 3);
+    for( int i = 0 ; i < 3 ; i++ )
+    {
+        ReData <<= 8;
+        ReData |= Wire.read();
+    }
+    return ReData;
+}
+
+uint32_t AXP192::Read32bit( uint8_t Addr )
+{
+    uint32_t ReData = 0;
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 4);
+    for( int i = 0 ; i < 4 ; i++ )
+    {
+        ReData <<= 8;
+        ReData |= Wire.read();
+    }
+    return ReData;
+}
+
+void AXP192::ReadBuff( uint8_t Addr , uint8_t Size , uint8_t *Buff )
+{
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(Addr);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, (int)Size);
+    for (int i = 0; i < Size; i++)
+    {
+        *( Buff + i )  = Wire.read();
+    }
+}
+
+void AXP192::ScreenBreath(uint8_t brightness)
+{
+    if (brightness > 12) 
+    {
+        brightness = 12;
+    }
+    uint8_t buf = Read8bit( 0x28 );
+    Write1Byte( 0x28 , ((buf & 0x0f) | (brightness << 4)) );
+}
+
+// Return True = Battery Exist
+bool AXP192::GetBatState()
+{
+    if( Read8bit(0x01) | 0x20 )
+        return true;
+    else
+        return false;
+}
+
+// Input Power Status 
+uint8_t AXP192::GetInputPowerStatus()
+{
+    return Read8bit(0x00);
+}
+
+// Battery Charging Status 
+uint8_t AXP192::GetBatteryChargingStatus()
+{
+    return Read8bit(0x01);
+}
+
+//---------coulombcounter_from_here---------
+//enable: void EnableCoulombcounter(void); 
+//disable: void DisableCOulombcounter(void);
+//stop: void StopCoulombcounter(void);
+//clear: void ClearCoulombcounter(void);
+//get charge data: uint32_t GetCoulombchargeData(void);
+//get discharge data: uint32_t GetCoulombdischargeData(void);
+//get coulomb val affter calculation: float GetCoulombData(void);
+//------------------------------------------
+void  AXP192::EnableCoulombcounter(void)
+{
+    Write1Byte( 0xB8 , 0x80 );
+}
+
+void  AXP192::DisableCoulombcounter(void)
+{
+    Write1Byte( 0xB8 , 0x00 );
+}
+
+void  AXP192::StopCoulombcounter(void)
+{
+    Write1Byte( 0xB8 , 0xC0 );
+}
+
+void  AXP192::ClearCoulombcounter(void)
+{
+    Write1Byte( 0xB8, Read8bit(0xB8) | 0x20);    // Only set the Clear Flag
+}
+
+uint32_t AXP192::GetCoulombchargeData(void)
+{
+    return Read32bit(0xB0);
+}
+
+uint32_t AXP192::GetCoulombdischargeData(void)
+{
+    return Read32bit(0xB4);
+}
+
+float AXP192::GetCoulombData(void)
+{
+    uint32_t coin = GetCoulombchargeData();
+    uint32_t coout = GetCoulombdischargeData();
+    uint32_t valueDifferent = 0;
+    bool bIsNegative = false;
+
+    if (coin > coout)
+    {    // Expected, in always more then out
+        valueDifferent = coin - coout;
+    }
+    else
+    {    // Warning: Out is more than In, the battery is not started at 0% 
+        // just Flip the output sign later
+        bIsNegative = true;
+        valueDifferent = coout - coin;
+    }
+    //c = 65536 * current_LSB * (coin - coout) / 3600 / ADC rate
+    //Adc rate can be read from 84H, change this variable if you change the ADC reate
+    float ccc = (65536 * 0.5 * valueDifferent) / 3600.0 / 200.0;  // Note the ADC has defaulted to be 200 Hz
+
+    if( bIsNegative )
+        ccc = 0.0 - ccc;    // Flip it back to negative
+    return ccc;
+}
+//----------coulomb_end_at_here----------
+
+uint8_t AXP192::GetWarningLeve(void)
+{
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(0x47);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 1);
+    uint8_t buf = Wire.read();
+    return (buf & 0x01);
+}
+
+void AXP192::SetSleep(void)
+{
+    Write1Byte(0x31 , Read8bit(0x31) | ( 1 << 3)); // Turn on short press to wake up
+    Write1Byte(0x90 , Read8bit(0x90) | 0x07); // GPIO1 floating
+    Write1Byte(0x82, 0x00); // Disable ADCs
+    Write1Byte(0x12, Read8bit(0x12) & 0xA1); // Disable all outputs but DCDC1
+}
+
+// Return 0 = not press, 0x01 = long press(1.5s), 0x02 = short press
+uint8_t AXP192::GetBtnPress()
+{
+    uint8_t state = Read8bit(0x46);  // IRQ 3 status.  
+    if(state) 
+    {
+        Write1Byte( 0x46 , 0x03 );   // Write 1 back to clear IRQ
+    }
+    return state;
+}
+
+// Low Volt Level 1, when APS Volt Output < 3.4496 V
+// Low Volt Level 2, when APS Volt Output < 3.3992 V, then this flag is SET (0x01)
+// Flag will reset once battery volt is charged above Low Volt Level 1
+// Note: now AXP192 have the Shutdown Voltage of 3.0V (B100) Def in REG 31H
+uint8_t AXP192::GetWarningLevel(void)
+{
+    return Read8bit(0x47) & 0x01;
+}
+
+float AXP192::GetBatVoltage()
+{
+    float ADCLSB = 1.1 / 1000.0;
+    uint16_t ReData = Read12Bit( 0x78 );
+    return ReData * ADCLSB;
+}
+
+float AXP192::GetBatCurrent()
+{
+    float ADCLSB = 0.5;
+    uint16_t CurrentIn = Read13Bit( 0x7A );
+    uint16_t CurrentOut = Read13Bit( 0x7C );
+    return ( CurrentIn - CurrentOut ) * ADCLSB;
+}
+
+float AXP192::GetVinVoltage()
+{
+    float ADCLSB = 1.7 / 1000.0;
+    uint16_t ReData = Read12Bit( 0x56 );
+    return ReData * ADCLSB;
+}
+
+float AXP192::GetVinCurrent()
+{
+    float ADCLSB = 0.625;
+    uint16_t ReData = Read12Bit( 0x58 );
+    return ReData * ADCLSB;
+}
+
+float AXP192::GetVBusVoltage()
+{
+    float ADCLSB = 1.7 / 1000.0;
+    uint16_t ReData = Read12Bit( 0x5A );
+    return ReData * ADCLSB;
+}
+
+float AXP192::GetVBusCurrent()
+{
+    float ADCLSB = 0.375;
+    uint16_t ReData = Read12Bit( 0x5C );
+    return ReData * ADCLSB;
+}
+
+float AXP192::GetTempInAXP192()
+{
+    float ADCLSB = 0.1;
+    const float OFFSET_DEG_C = -144.7;
+    uint16_t ReData = Read12Bit( 0x5E );
+    return OFFSET_DEG_C + ReData * ADCLSB;
+}
+
+float AXP192::GetBatPower()
+{
+    float VoltageLSB = 1.1;
+    float CurrentLCS = 0.5;
+    uint32_t ReData = Read24bit( 0x70 );
+    return  VoltageLSB * CurrentLCS * ReData/ 1000.0;
+}
+
+float AXP192::GetBatChargeCurrent()
+{
+    float ADCLSB = 0.5;
+    uint16_t ReData = Read13Bit( 0x7A );
+    return ReData * ADCLSB;
+}
+
+float AXP192::GetAPSVoltage()
+{
+    float ADCLSB = 1.4  / 1000.0;
+    uint16_t ReData = Read12Bit( 0x7E );
+    return ReData * ADCLSB;
+}
+
+float AXP192::GetBatCoulombInput()
+{
+    uint32_t ReData = Read32bit( 0xB0 );
+    return ReData * 65536 * 0.5 / 3600 /25.0;
+}
+
+float AXP192::GetBatCoulombOut()
+{
+    uint32_t ReData = Read32bit( 0xB4 );
+    return ReData * 65536 * 0.5 / 3600 /25.0;
+}
+
+// Can turn LCD Backlight OFF for power saving
+void AXP192::SetLDO2( bool State )
+{
+    uint8_t buf = Read8bit(0x12);
+    if( State == true )
+    {
+        buf = (1<<2) | buf;
+    }
+    else
+    {
+        buf = ~(1<<2) & buf;
+    }
+    Write1Byte( 0x12 , buf );
+}
+
+void AXP192::SetLDO3(bool State)
+{
+    uint8_t buf = Read8bit(0x12);
+    if( State == true )
+    {
+        buf = (1<<3) | buf;
+    }
+    else
+    {
+        buf = ~(1<<3) & buf;
+    }
+    Write1Byte( 0x12 , buf );
+}
+
+// Not recommend to set charge current > 100mA, since Battery is only 80mAh.
+// more then 1C charge-rate may shorten battery life-span.
+void AXP192::SetChargeCurrent(uint8_t current)
+{
+    uint8_t buf = Read8bit(0x33);
+    buf = (buf & 0xf0) | (current & 0x07);
+    Write1Byte(0x33, buf);
+}
+
+// Cut all power, except for LDO1 (RTC)
+void AXP192::PowerOff()
+{
+    Write1Byte(0x32, Read8bit(0x32) | 0x80);     // MSB for Power Off
+}
+
+void AXP192::SetAdcState(bool state)
+{
+    Write1Byte(0x82, state ? 0xff : 0x00);  // Enable / Disable all ADCs
+}
+
+// AXP192 have a 6 byte storage, when the power is still valid, the data will not be lost
+void AXP192::Read6BytesStorage( uint8_t *bufPtr )
+{
+    // Address from 0x06 - 0x0B
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(0x06);
+    Wire.endTransmission();
+    Wire.requestFrom(AXP_ADDR, 6);
+    for( int i = 0; i < 6; ++i )
+    {
+        bufPtr[i] = Wire.read();
+    }
+}
+
+// AXP192 have a 6 byte storage, when the power is still valid, the data will not be lost
+void AXP192::Write6BytesStorage( uint8_t *bufPtr )
+{
+    // Address from 0x06 - 0x0B
+    Wire.beginTransmission(AXP_ADDR);
+    Wire.write(0x06);
+    Wire.write(bufPtr[0]);
+    Wire.write(0x07);
+    Wire.write(bufPtr[1]);
+    Wire.write(0x08);
+    Wire.write(bufPtr[2]);
+    Wire.write(0x09);
+    Wire.write(bufPtr[3]);
+    Wire.write(0x0A);
+    Wire.write(bufPtr[4]);
+    Wire.write(0x0B);
+    Wire.write(bufPtr[5]);
+    Wire.endTransmission();
+}

--- a/libraries/AXP192/AXP192.h
+++ b/libraries/AXP192/AXP192.h
@@ -1,0 +1,94 @@
+#ifndef __AXP192_H__
+#define __AXP192_H__
+
+#include <Wire.h>
+#include <Arduino.h>
+
+#define SLEEP_MSEC(us) (((uint64_t)us) * 1000L)
+#define SLEEP_SEC(us)  (((uint64_t)us) * 1000000L)
+#define SLEEP_MIN(us)  (((uint64_t)us) * 60L * 1000000L)
+#define SLEEP_HR(us)   (((uint64_t)us) * 60L * 60L * 1000000L)
+
+#define AXP_ADDR 0X34
+
+#define CURRENT_100MA  (0b0000)
+#define CURRENT_190MA  (0b0001)
+#define CURRENT_280MA  (0b0010)
+#define CURRENT_360MA  (0b0011)
+#define CURRENT_450MA  (0b0100)
+#define CURRENT_550MA  (0b0101)
+#define CURRENT_630MA  (0b0110)
+#define CURRENT_700MA  (0b0111)
+
+class AXP192 {
+public:
+
+    AXP192();
+    /**
+     * DCDC1: 3V3 Main rail. When not set the stick shuts down
+     * DCDC2: 0V9 K210 VCore
+     * DCDC3: 1V8 Use unknown
+     * LDO1: Don't set GPIO1 as LDO
+     * LDO2: 2V8 Display backlight
+     * LDO3: 1V5 Display Control
+     * GPIO0: LDO1 LCD_BL
+     * EXTEN:
+     */
+    void  begin(bool isInited = false);
+    void  ScreenBreath(uint8_t brightness);
+    bool  GetBatState();
+  
+    uint8_t GetInputPowerStatus();
+    uint8_t GetBatteryChargingStatus();
+
+    void  EnableCoulombcounter(void);
+    void  DisableCoulombcounter(void);
+    void  StopCoulombcounter(void);
+    void  ClearCoulombcounter(void);
+    uint32_t GetCoulombchargeData(void);        // Raw Data for Charge
+    uint32_t GetCoulombdischargeData(void);     // Raw Data for Discharge
+    float GetCoulombData(void);                 // total in - total out and calc
+    uint8_t GetBtnPress(void);
+    void SetSleep(void);
+    uint8_t GetWarningLeve(void);
+
+public:
+    // void SetChargeVoltage( uint8_t );
+    void  SetChargeCurrent( uint8_t );
+    float GetBatVoltage();
+    float GetBatCurrent();
+    float GetVinVoltage();
+    float GetVinCurrent();
+    float GetVBusVoltage();
+    float GetVBusCurrent();
+    float GetTempInAXP192();
+    float GetBatPower();
+    float GetBatChargeCurrent();
+    float GetAPSVoltage();
+    float GetBatCoulombInput();
+    float GetBatCoulombOut();
+    uint8_t GetWarningLevel(void);    
+    void SetLDO2( bool State );     // Can turn LCD Backlight OFF for power saving
+    void SetLDO3( bool State );
+    void SetAdcState(bool State);
+    
+    // -- Power Off
+    void PowerOff();
+
+    // Power Maintained Storage
+    void Read6BytesStorage( uint8_t *bufPtr );
+    void Write6BytesStorage( uint8_t *bufPtr );
+
+    
+private:
+    void Write1Byte( uint8_t Addr ,  uint8_t Data );
+    uint8_t Read8bit( uint8_t Addr );
+    uint16_t Read12Bit( uint8_t Addr);
+    uint16_t Read13Bit( uint8_t Addr);
+    uint16_t Read16bit( uint8_t Addr );
+    uint32_t Read24bit( uint8_t Addr );
+    uint32_t Read32bit( uint8_t Addr );
+    void ReadBuff( uint8_t Addr , uint8_t Size , uint8_t *Buff );
+}; 
+
+#endif

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -56,7 +56,8 @@ TwoWire::begin(uint8_t sda, uint8_t scl, uint32_t frequency)
     
     is_master_mode = true;
     
-    delete i2c_tx_buff, i2c_rx_buff;
+    delete i2c_tx_buff;
+    delete i2c_rx_buff;
     i2c_tx_buff = new RingBuffer();
     i2c_rx_buff = new RingBuffer();
 
@@ -88,7 +89,8 @@ TwoWire::begin(uint16_t slave_address, uint8_t sda, uint8_t scl)
     plic_irq_register((plic_irq_t)(IRQN_I2C0_INTERRUPT + _i2c_num), maix_i2c_slave_irq, this);
     plic_irq_enable((plic_irq_t)(IRQN_I2C0_INTERRUPT + _i2c_num));
 
-    delete i2c_tx_buff, i2c_rx_buff;
+    delete i2c_tx_buff;
+    delete i2c_rx_buff;
     i2c_tx_buff = new RingBuffer();
     i2c_rx_buff = new RingBuffer();
 

--- a/variants/m5stack_m5stick_v/pins_arduino.h
+++ b/variants/m5stack_m5stick_v/pins_arduino.h
@@ -1,0 +1,93 @@
+#ifndef _VARIANT_M5STACK_M5STICK_V
+#define _VARIANT_M5STACK_M5STICK_V
+
+#include <stdint.h>
+
+#define RISCV
+#include "platform.h"
+
+#include "Arduino.h"
+#include "pwm.h"
+
+#ifdef __cplusplus
+#include "UARTClass.h"
+extern class UARTHSClass Serial;
+extern class UARTClass Serial1;
+extern class UARTClass Serial2;
+extern class UARTClass Serial3;
+#endif
+
+/* BOARD  PIN DEFINE */
+/* UART */
+#define RX0                   4
+#define TX0                   5
+/* LEDs */
+#define PIN_LED_RED           6
+#define PIN_LED_WHITE         7
+#define PIN_LED_BLUE          8
+#define PIN_LED_GREEN         9
+#define PIN_LED               9
+#define LED_RED               6
+#define LED_WHITE             7
+#define LED_BLUE              8
+#define LED_GREEN             9
+#define LED_BUILTIN           9
+/* MIC ARRAY */
+#define MIC_WS               10
+#define MIC_DAT3             12
+#define MIC_BCK              13
+/* SPK MAX98357 */
+#define I2S_SD               11
+#define I2S_LRCLK            14
+#define I2S_BCLK             15
+#define I2S_DIN              17
+/* LCD ST7789 135x240 */
+#define LCD_SDA              18
+#define LCD_SCL              19
+#define LCD_DC               20
+#define LCD_RST              21
+#define LCD_CS               22
+/* AXP192 INT PIN */
+#define INTL_INT             23
+/* INTL I2C - AXP192, MPU6886 */
+#define SCL                  28
+#define SDA                  29
+/* SPI0 */
+#define SPI0_SCLK            30
+#define SPI0_MISO            31
+#define SPI0_CS0             32
+#define SPI0_MOSI            33
+/* GROVE */
+#define RX1                  34
+#define TX1                  35
+#define EXTL_SCL             34
+#define EXTL_SDA             35
+/* BUTTONS */
+#define BTN_A                36
+#define BTN_B                37
+#define KEY0                 36
+#define KEY1                 37
+
+#define MD_PIN_MAP(fpio)   (fpio)
+#define ORG_PIN_MAP(org_pin)    (org_pin)
+
+static const uint8_t SS   = SPI0_CS0 ;
+static const uint8_t MOSI = SPI0_MOSI;
+static const uint8_t MISO = SPI0_MISO;
+static const uint8_t SCK  = SPI0_SCLK;
+
+typedef struct _pwm_fpio_set_t{
+    pwm_channel_number_t channel;
+    pwm_device_number_t device;
+    uint8_t inuse;
+} pwm_fpio_set_t;
+
+
+#define VARIANT_NUM_GPIOHS (32)
+#define VARIANT_NUM_GPIO   ( 8)
+#define VARIANT_NUM_PWM    (12)
+#define VARIANT_NUM_I2C    ( 3)
+#define VARIANT_NUM_SPI    ( 3)
+#define VARIANT_NUM_UART   ( 3)
+
+#endif

--- a/variants/m5stack_m5unit_v/pins_arduino.h
+++ b/variants/m5stack_m5unit_v/pins_arduino.h
@@ -1,0 +1,78 @@
+#ifndef _VARIANT_M5STACK_M5UNIT_V
+#define _VARIANT_M5STACK_M5UNIT_V
+
+#include <stdint.h>
+
+#define RISCV
+#include "platform.h"
+
+#include "Arduino.h"
+#include "pwm.h"
+
+#ifdef __cplusplus
+#include "UARTClass.h"
+extern class UARTHSClass Serial;
+extern class UARTClass Serial1;
+extern class UARTClass Serial2;
+extern class UARTClass Serial3;
+#endif
+
+/* BOARD  PIN DEFINE */
+/* UART */
+#define RX0                   4
+#define TX0                   5
+/* WS2812 LEDs */
+#define PIN_LED_RGB           8
+
+/* MIC ARRAY */
+#define MIC_WS               10
+#define MIC_DAT3             12
+#define MIC_BCK              13
+/* SPK MAX98357 */
+#define SPK_LRCLK            14
+#define SPK_BCLK             15
+#define SPK_DIN              17
+#define SPK_SD               25
+/* BUTTONS */
+#define BTN_A                18
+#define BTN_B                19
+#define KEY0                 18
+#define KEY1                 19
+/* AXP192 INT PIN */
+#define AXP_INT              23
+/* INTL I2C */
+#define SCL                  28
+#define SDA                  29
+/* SPI0 */
+#define SPI0_SCLK            30
+#define SPI0_MISO            31
+#define SPI0_CS0             32
+#define SPI0_MOSI            33
+/* EXTL I2C */
+#define EXTL_SCL             34
+#define EXTL_SDA             35
+
+
+#define MD_PIN_MAP(fpio)   (fpio)
+#define ORG_PIN_MAP(org_pin)    (org_pin)
+
+static const uint8_t SS   = SPI0_CS0 ;
+static const uint8_t MOSI = SPI0_MOSI;
+static const uint8_t MISO = SPI0_MISO;
+static const uint8_t SCK  = SPI0_SCLK;
+
+typedef struct _pwm_fpio_set_t{
+    pwm_channel_number_t channel;
+    pwm_device_number_t device;
+    uint8_t inuse;
+}pwm_fpio_set_t;
+ 
+
+#define VARIANT_NUM_GPIOHS (32)
+#define VARIANT_NUM_GPIO   ( 8)
+#define VARIANT_NUM_PWM    (12)
+#define VARIANT_NUM_I2C    ( 3)
+#define VARIANT_NUM_SPI    ( 3)
+#define VARIANT_NUM_UART   ( 3)
+
+#endif

--- a/variants/sipeed_maix_amigo/pins_arduino.h
+++ b/variants/sipeed_maix_amigo/pins_arduino.h
@@ -1,0 +1,96 @@
+#ifndef _VARIANT_SIPEED_MAIX_AMIGO
+#define _VARIANT_SIPEED_MAIX_AMIGO
+
+#include <stdint.h>
+
+#define RISCV
+#include "platform.h"
+
+#include "Arduino.h"
+#include "pwm.h"
+
+#ifdef __cplusplus
+#include "UARTClass.h"
+extern class UARTHSClass Serial;
+extern class UARTClass Serial1;
+extern class UARTClass Serial2;
+extern class UARTClass Serial3;
+#endif
+
+/* BOARD  PIN DEFINE */
+/* UARTHS CH552T */
+#define RX0                   4
+#define TX0                   5
+/* UART Grove */
+#define RX1                   9 //Grove
+#define TX1                   7 //Grove
+/* 8P Connector */
+// #define PB0                   8 //8P-12
+// #define PB1                  12 //8P-3
+/* SPI0 */
+#define SPI0_MISO             6 //8P-11
+#define SPI0_MOSI            10 //8P-2
+#define SPI0_SCLK            11 //8P-1
+#define SPI0_CS0             26 //TF
+/* KEYs */
+#define KEY2                 20 //Grove
+#define KEY1                 23 //Grove      
+/* LEDs */
+#define PIN_LED_RED          14
+#define PIN_LED_GREEN        15
+#define PIN_LED_BLUE         17
+#define PIN_LED              15
+#define LED_RED              14
+#define LED_GREEN            15
+#define LED_BLUE             17
+#define LED_BUILTIN          15
+/* UART3 */
+#define TX2                  22 //8P-4
+#define RX2                  25 //8P-5
+/* I2C1 - AXP173, MSA301, TOUCH */
+#define SCL                  24
+#define SDA                  27
+/* USB_SBU */
+#define USB_DP               28 //8P-8
+#define USB_DM               29 //8P-9
+/* I2S AUDIO CODEC ES8374 */
+#define I2S2_MCLK            13
+#define I2S2_WS              18
+#define I2S2_SCLK            21
+#define I2S2_DOUT            34
+#define I2S2_DIN             35
+/* Flash LED */
+#define WLED_EN              32
+/* TouchScreen */
+#define CAP_TOUCH_IRQ        33
+/* LCD */
+#define LCD_TEN              19
+#define LCD_CS               36
+#define LCD_RST              37
+#define LCD_DC               38
+#define LCD_WR               39
+
+
+#define MD_PIN_MAP(fpio)   (fpio)
+#define ORG_PIN_MAP(org_pin)    (org_pin)
+
+static const uint8_t SS   = SPI0_CS0 ;
+static const uint8_t MOSI = SPI0_MOSI;
+static const uint8_t MISO = SPI0_MISO;
+static const uint8_t SCK  = SPI0_SCLK;
+
+typedef struct _pwm_fpio_set_t{
+    pwm_channel_number_t channel;
+    pwm_device_number_t device;
+    uint8_t inuse;
+} pwm_fpio_set_t;
+
+
+#define VARIANT_NUM_GPIOHS (32)
+#define VARIANT_NUM_GPIO   ( 8)
+#define VARIANT_NUM_PWM    (12)
+#define VARIANT_NUM_I2C    ( 3)
+#define VARIANT_NUM_SPI    ( 3)
+#define VARIANT_NUM_UART   ( 3)
+
+#endif

--- a/variants/sipeed_maix_bit/pins_arduino.h
+++ b/variants/sipeed_maix_bit/pins_arduino.h
@@ -18,45 +18,58 @@ extern class UARTClass Serial3;
 #endif
 
 /* BOARD  PIN DEFINE */
+/* UARTHS */
+#define RX0                   4
+#define TX0                   5
+/* UART */
+#define RX1                   6
+#define TX1                   7
+
+// #define IO_8                  8
+// #define IO_9                  9
+// #define IO_10                10
 /* LEDs */
-#define PIN_LED_GREEN        13
-#define PIN_LED_BLUE         12
-#define PIN_LED_RED          14
-#define PIN_LED              13
-#define LED_BUILTIN          13
-#define LED_GREEN            13
-#define LED_BLUE             12
-#define LED_RED              14
-/* KEY */
-#define KEY0                 16
-/* MIC ARRAY */
+#define PIN_LED_GREEN        12
+#define PIN_LED_RED          13
+#define PIN_LED_BLUE         14
+#define PIN_LED              12
+#define LED_RED              13
+#define LED_GREEN            12
+#define LED_BLUE             14
+#define LED_BUILTIN          12
+// #define IO_15                15
+// #define IO_17                17
+
+/* I2S MIC */
 #define MIC_BCK              18
 #define MIC_WS               19
 #define MIC_DAT3             20
-#define MIC_DAT2             21
-#define MIC_DAT1             22
-#define MIC_DAT0             23
-#define MIC_LED_DAT          24
+
+// #define IO_21                21
+// #define IO_22                22
+// #define IO_23                23
+// #define IO_24                24
+// #define IO_25                25
 /* SPI0 */
-#define SPI0_CS1             25
 #define SPI0_MISO            26
 #define SPI0_SCLK            27
 #define SPI0_MOSI            28
 #define SPI0_CS0             29
+
+// #define SCL                  30
+// #define SDA                  31
+// #define IO_30                30
+// #define IO_31                31
+// #define IO_32                32
+// #define IO_33                33
+// #define IO_34                34
+// #define IO_35                35
 /* LCD */
 #define LCD_CS               36
 #define LCD_RST              37
 #define LCD_DC               38
 #define LCD_WR               39
 
-#define RX0                   4
-#define TX0                   5
-
-#define RX1                   6
-#define TX1                   7
-
-#define SDA                  31
-#define SCL                  30
 
 #define MD_PIN_MAP(fpio)   (fpio)
 #define ORG_PIN_MAP(org_pin)    (org_pin)
@@ -70,8 +83,7 @@ typedef struct _pwm_fpio_set_t{
     pwm_channel_number_t channel;
     pwm_device_number_t device;
     uint8_t inuse;
-}pwm_fpio_set_t;
-
+} pwm_fpio_set_t;
 
 
 #define VARIANT_NUM_GPIOHS (32)

--- a/variants/sipeed_maix_bit_mic/pins_arduino.h
+++ b/variants/sipeed_maix_bit_mic/pins_arduino.h
@@ -18,45 +18,56 @@ extern class UARTClass Serial3;
 #endif
 
 /* BOARD  PIN DEFINE */
+/* UARTHS */
+#define RX0                   4
+#define TX0                   5
+/* UART */
+#define RX1                   6
+#define TX1                   7
+
+#define IO_8                  8
+#define IO_9                  9
+#define IO_10                10
 /* LEDs */
-#define PIN_LED_GREEN        13
-#define PIN_LED_BLUE         12
-#define PIN_LED_RED          14
-#define PIN_LED              13
-#define LED_BUILTIN          13
-#define LED_GREEN            13
-#define LED_BLUE             12
-#define LED_RED              14
-/* KEY */
-#define KEY0                 16
-/* MIC ARRAY */
+#define PIN_LED_GREEN        12
+#define PIN_LED_RED          13
+#define PIN_LED_BLUE         14
+#define PIN_LED              12
+#define LED_RED              13
+#define LED_GREEN            12
+#define LED_BLUE             14
+#define LED_BUILTIN          12
+// #define IO_15                15
+// #define IO_17                17
+/* I2S MIC */
 #define MIC_BCK              18
 #define MIC_WS               19
 #define MIC_DAT3             20
-#define MIC_DAT2             21
-#define MIC_DAT1             22
-#define MIC_DAT0             23
-#define MIC_LED_DAT          24
+// #define IO_21                21
+// #define IO_22                22
+// #define IO_23                23
+// #define IO_24                24
+// #define IO_25                25
 /* SPI0 */
-#define SPI0_CS1             25
 #define SPI0_MISO            26
 #define SPI0_SCLK            27
 #define SPI0_MOSI            28
 #define SPI0_CS0             29
+
+// #define SCL                  30
+// #define SDA                  31
+// #define IO_30                30
+// #define IO_31                31
+// #define IO_32                32
+// #define IO_33                33
+// #define IO_34                34
+// #define IO_35                35
 /* LCD */
 #define LCD_CS               36
 #define LCD_RST              37
 #define LCD_DC               38
 #define LCD_WR               39
 
-#define RX0                   4
-#define TX0                   5
-
-#define RX1                   6
-#define TX1                   7
-
-#define SDA                  31
-#define SCL                  30
 
 #define MD_PIN_MAP(fpio)   (fpio)
 #define ORG_PIN_MAP(org_pin)    (org_pin)
@@ -70,8 +81,7 @@ typedef struct _pwm_fpio_set_t{
     pwm_channel_number_t channel;
     pwm_device_number_t device;
     uint8_t inuse;
-}pwm_fpio_set_t;
-
+} pwm_fpio_set_t;
 
 
 #define VARIANT_NUM_GPIOHS (32)

--- a/variants/sipeed_maix_cube/pins_arduino.h
+++ b/variants/sipeed_maix_cube/pins_arduino.h
@@ -1,5 +1,5 @@
-#ifndef _VARIANT_SIPEED_MAIX_GO
-#define _VARIANT_SIPEED_MAIX_GO
+#ifndef _VARIANT_SIPEED_MAIX_CUBE
+#define _VARIANT_SIPEED_MAIX_CUBE
 
 #include <stdint.h>
 
@@ -18,59 +18,56 @@ extern class UARTClass Serial3;
 #endif
 
 /* BOARD  PIN DEFINE */
-/* UARTHS */
+/* UARTHS CH552T */
 #define RX0                   4
 #define TX0                   5
-/* WIFI UART1 */
+/* SPMOD */
 #define RX1                   6
 #define TX1                   7
-#define ESP_TX                6
-#define ESP_RX                7
-#define ESP_EN                8
-/* BPSK */
-#define BPSK_P                9
-#define BPSK_N               10
-// #define IO_11                11
+// #define IO_8                  8
+// #define IO_9                  9
+/* KEYs */
+#define KEY1                 10
+#define KEY2                 11
+#define PIN_KEY_DOWN         10
+#define PIN_KEY_UP           11
 /* LEDs */
-#define PIN_LED_BLUE         12
-#define PIN_LED_GREEN        13
-#define PIN_LED_RED          14
-#define PIN_LED              13
-#define LED_RED              14
-#define LED_GREEN            13
-#define LED_BLUE             12
-#define LED_BUILTIN          13
-/* KEY */
-#define KEY1                 15
-#define KEY0                 16
-#define KEY2                 17
-#define PIN_KEY_DOWN         15
-#define PIN_KEY_PRESS        16
-#define PIN_KEY_UP           17
-/* MIC ARRAY */
-/* I2S MIC MSM261S4030H0 */
-#define MIC_BCK              18
-#define MIC_WS               19
-#define MIC_DAT3             20
-#define MIC_DAT2             21
-#define MIC_DAT1             22
-#define MIC_DAT0             23
-#define MIC_LED_DAT          24
-#define MIC_LED_CLK          25
-/* SPI0 TF */
+#define PIN_LED_GREEN        12
+#define PIN_LED_RED          13
+#define PIN_LED_BLUE         14
+#define PIN_LED              12
+#define LED_RED              13
+#define LED_GREEN            12
+#define LED_BLUE             14
+#define LED_BUILTIN          12
+/* SPMOD */
+// #define IO_15                15
+// #define IO_20                20
+// #define IO_21                21
+/* I2S AUDIO CODEC ES8374 */
+#define I2S_DIN              18
+#define I2S_MCLK             19
+#define I2S_LRCK             33
+#define I2S_DOUT             34
+#define I2S_SCLK             35
+/* USB_SBU */
+// #define IO_22                22
+// #define IO_23                23
+/* GROVE */
+// #define IO_24                24
+// #define IO_25                25
+/* SPI0 */
 #define SPI0_MISO            26
 #define SPI0_SCLK            27
 #define SPI0_MOSI            28
 #define SPI0_CS0             29
-/* I2C1 MSA300 */
+/* I2C1 - AXP173, MSA301*/
 #define SCL                  30
 #define SDA                  31
-// #define IO_32                32
-/* I2S DAC PT8211 */
-#define I2S_WS               33
-#define I2S_DA               34
-#define I2S_BCK              35
+/* Flash LED */
+#define WLED_EN              32
 /* LCD */
+#define LCD_BL               17
 #define LCD_CS               36
 #define LCD_RST              37
 #define LCD_DC               38

--- a/variants/sipeed_maix_one_dock/pins_arduino.h
+++ b/variants/sipeed_maix_one_dock/pins_arduino.h
@@ -1,5 +1,5 @@
-#ifndef _VARIANT_SIPEED_M1_DOCK
-#define _VARIANT_SIPEED_M1_DOCK
+#ifndef _VARIANT_SIPEED_MAIX_ONE_DOCK
+#define _VARIANT_SIPEED_MAIX_ONE_DOCK
 
 #include <stdint.h>
 
@@ -18,17 +18,23 @@ extern class UARTClass Serial3;
 #endif
 
 /* BOARD  PIN DEFINE */
+/* UARTHS */
+#define RX0                   4
+#define TX0                   5
+/* WIFI UART1 */
+#define RX1                   6
+#define TX1                   7
 /* LEDs */
 #define PIN_LED_GREEN        13
 #define PIN_LED_BLUE         12
 #define PIN_LED_RED          14
 #define PIN_LED              13
-#define LED_BUILTIN          13
+#define LED_RED              14
 #define LED_GREEN            13
 #define LED_BLUE             12
-#define LED_RED              14
+#define LED_BUILTIN          13
 /* KEY */
-#define KEY0                 16
+//#define KEY0                 16
 /* MIC ARRAY */
 #define MIC_BCK              18
 #define MIC_WS               19
@@ -56,14 +62,6 @@ extern class UARTClass Serial3;
 #define LCD_DC               38
 #define LCD_WR               39
 
-#define RX0                   4
-#define TX0                   5
-
-#define RX1                   6
-#define TX1                   7
-
-#define SDA                  31
-#define SCL                  30
 
 #define MD_PIN_MAP(fpio)   (fpio)
 #define ORG_PIN_MAP(org_pin)    (org_pin)

--- a/variants/sipeed_maix_one_w_dock/pins_arduino.h
+++ b/variants/sipeed_maix_one_w_dock/pins_arduino.h
@@ -1,5 +1,5 @@
-#ifndef _VARIANT_SIPEED_MAIX_GO
-#define _VARIANT_SIPEED_MAIX_GO
+#ifndef _VARIANT_SIPEED_MAIX_ONE_W_DOCK
+#define _VARIANT_SIPEED_MAIX_ONE_W_DOCK
 
 #include <stdint.h>
 
@@ -24,31 +24,18 @@ extern class UARTClass Serial3;
 /* WIFI UART1 */
 #define RX1                   6
 #define TX1                   7
-#define ESP_TX                6
-#define ESP_RX                7
-#define ESP_EN                8
-/* BPSK */
-#define BPSK_P                9
-#define BPSK_N               10
-// #define IO_11                11
 /* LEDs */
-#define PIN_LED_BLUE         12
-#define PIN_LED_GREEN        13
 #define PIN_LED_RED          14
+#define PIN_LED_GREEN        13
+#define PIN_LED_BLUE         12
 #define PIN_LED              13
 #define LED_RED              14
 #define LED_GREEN            13
 #define LED_BLUE             12
 #define LED_BUILTIN          13
 /* KEY */
-#define KEY1                 15
-#define KEY0                 16
-#define KEY2                 17
-#define PIN_KEY_DOWN         15
-#define PIN_KEY_PRESS        16
-#define PIN_KEY_UP           17
+//#define KEY0                 16
 /* MIC ARRAY */
-/* I2S MIC MSM261S4030H0 */
 #define MIC_BCK              18
 #define MIC_WS               19
 #define MIC_DAT3             20
@@ -56,17 +43,17 @@ extern class UARTClass Serial3;
 #define MIC_DAT1             22
 #define MIC_DAT0             23
 #define MIC_LED_DAT          24
-#define MIC_LED_CLK          25
-/* SPI0 TF */
+/* SPI0 */
+#define SPI0_CS1             25
 #define SPI0_MISO            26
 #define SPI0_SCLK            27
 #define SPI0_MOSI            28
 #define SPI0_CS0             29
-/* I2C1 MSA300 */
-#define SCL                  30
-#define SDA                  31
-// #define IO_32                32
-/* I2S DAC PT8211 */
+/* I2S */
+#define MIC0_WS              30
+#define MIC0_DATA            31
+#define MIC0_BCK             32
+
 #define I2S_WS               33
 #define I2S_DA               34
 #define I2S_BCK              35
@@ -89,7 +76,8 @@ typedef struct _pwm_fpio_set_t{
     pwm_channel_number_t channel;
     pwm_device_number_t device;
     uint8_t inuse;
-} pwm_fpio_set_t;
+}pwm_fpio_set_t;
+
 
 
 #define VARIANT_NUM_GPIOHS (32)

--- a/variants/sipeed_maixduino/pins_arduino.h
+++ b/variants/sipeed_maixduino/pins_arduino.h
@@ -18,47 +18,48 @@ extern class UARTClass Serial3;
 #endif
 
 /* BOARD  PIN DEFINE */
+#define RX0                   0
+#define TX0                   1
 /* LEDs (USE Builtin TX PIN led)*/
-#define PIN_LED              1
-#define LED_BUILTIN          1
-
+#define PIN_LED_RED          13
+#define PIN_LED_GREEN        12
+#define PIN_LED_BLUE         14
+#define PIN_LED              12
+#define LED_RED              13
+#define LED_GREEN            12
+#define LED_BLUE             14
+#define LED_BUILTIN          12
 /* KEY */
-#define KEY0                 16
-/* MIC ARRAY */
-#define MIC_BCK              18
-#define MIC_WS               19
-#define MIC_DAT3             20
-#define MIC_DAT2             21
-#define MIC_DAT1             22
-#define MIC_DAT0             23
-#define MIC_LED_DAT          24
+//#define KEY0                 16
+/* ONBOARD ESP32 */
+#define ESP_TX                6
+#define ESP_RX                7
+#define ESP_EN                8
+#define ESP_READY             9
+#define ESP_SPI_CS           25
 /* SPI0 */
-#define SPI0_CS1             25
 #define SPI0_MISO            26
 #define SPI0_SCLK            27
 #define SPI0_MOSI            28
 #define SPI0_CS0             29
 /* I2S */
-#define MIC0_WS              30
-#define MIC0_DATA            31
-#define MIC0_BCK             32
+#define MIC_BCK              18
+#define MIC_WS               19
+#define MIC_DATA             20
+/* I2C1 */
+#define SCL                  30
+#define SDA                  31
+/* DAC PT8211 */
 #define I2S_WS               33
 #define I2S_DA               34
 #define I2S_BCK              35
 /* LCD */
+#define LCD_BL               17
 #define LCD_CS               36
 #define LCD_RST              37
 #define LCD_DC               38
 #define LCD_WR               39
 
-#define RX0                   0
-#define TX0                   1
-
-#define RX1                   6
-#define TX1                   7
-
-#define SDA                  31
-#define SCL                  30
 
 static const uint8_t SS   = SPI0_CS0 ;
 static const uint8_t MOSI = SPI0_MOSI;


### PR DESCRIPTION
Missing boards added to add K210 support to TFT_eSPI library.
Tested on Maix Amigo, Maix Go, Maix Dock M1W, M5StickV with TFT_eSPI K210 port by [ fukuen /
TFT_eSPI ](https://github.com/fukuen/TFT_eSPI)
boardID.build.board property is shortened to get usable compile-time variable ARDUINO_{build.board} (if it works).
Minimal AXP173/AXP192 support added to provide power for Maix Amigo/Cube and M5StickV devices - all credits go to [https://qiita.com/fukuebiz](https://qiita.com/fukuebiz/items/59915590a124a83061f1)