### PR TITLE
Fixed some bugs in the Serial implementations

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -29,6 +29,7 @@ class HardwareSerial : public Stream
     virtual void begin(uint32_t) {};
     virtual void end() {};
     virtual int available(void) = 0;
+    virtual int availableForWrite(void) = 0;
     virtual int peek(void) = 0;
     virtual int read(void) = 0;
     virtual void flush(void) = 0;

--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -45,12 +45,12 @@ size_t Print::printf(const char *format, ...)
         }
     }
     len = vsnprintf(temp, len+1, format, arg);
-    write((uint8_t*)temp, len);
+    size_t ret = write((uint8_t*)temp, len);
     va_end(arg);
     if(len >= sizeof(loc_buf)){
         delete[] temp;
     }
-    return len;
+    return ret;
 }
 
 /* default implementation: may be overridden */
@@ -58,7 +58,12 @@ size_t Print::write(const uint8_t *buffer, size_t size)
 {
   size_t n = 0;
   while (size--) {
-    n += write(*buffer++);
+    size_t ret = write(*buffer++);
+    if (ret == 0) {
+        // Write of last byte didn't complete, abort additional processing
+        break;
+    }
+    n += ret;
   }
   return n;
 }

--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -128,7 +128,7 @@ UARTClass::write(const uint8_t c)
   while (uart[this->_uart]->LSR & (1u << 5))
         continue;
   uart[this->_uart]->THR = c;
-  return 0;
+  return 1;
 }
 
 static int 
@@ -177,8 +177,11 @@ UARTHSClass::end()
 size_t
 UARTHSClass::write(const uint8_t uc_data)
 {
-  uarths_putchar(uc_data);
-  return (1);
+  if (uarths_putchar(uc_data) == uc_data) {
+    return 1;
+  }
+
+  return 0;
 }
 
 static int
@@ -186,7 +189,7 @@ uarths_rec_callback(void *ctx)
 {
   int data;
   auto &driver = *reinterpret_cast<UARTHSClass *>(ctx);
-  data = uarths_getc();
+  data = uarths_getchar();
   if(data != EOF){
     driver._buff->store_char((char)data);
   }


### PR DESCRIPTION
tl;dr I fixed return value handling of UARTClass::write and Print::write

* UARTClass::write was always return 0 as the number of bytes written. It should return 1, which is the number of bytes written to the UART
* Print::write(buf, len) method wasn't considering the return values from the write(c) method
* uarths_rec_callback() was using deprecated Kendryte SDK function uarths_getc()
* HardwareSerial::availableForWrite() method wasn't exposed in the interface