### PR TITLE
BugFix/serial1-3

### DIFF
--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -72,8 +72,8 @@ UARTClass::begin(uint32_t dwBaudRate)
 void
 UARTClass::begin(uint32_t dwBaudRate, uint8_t _rx, uint8_t _tx)
 {
-  fpioa_set_function((int)MD_PIN_MAP(_rx), this->_rxfunc);
-  fpioa_set_function((int)MD_PIN_MAP(_tx), this->_txfunc);
+  fpioa_set_function(_rx, this->_rxfunc);
+  fpioa_set_function(_tx, this->_txfunc);
   uart_init(this->_uart);
   uart_configure(this->_uart, dwBaudRate, UART_BITWIDTH_8BIT, UART_STOP_1, UART_PARITY_NONE);
   this->_buff = new RingBuffer();

--- a/variants/ioxgd4/pins_arduino.h
+++ b/variants/ioxgd4/pins_arduino.h
@@ -59,8 +59,8 @@ extern class UARTClass Serial3;
 #define RX0                   4
 #define TX0                   5
 
-#define RX1                   6
-#define TX1                   7
+#define RX1                   7
+#define TX1                   6
 
 #define SDA                  33
 #define SCL                  32


### PR DESCRIPTION
- edit RX1/TX1 pin number define in pins_arduino.h because was wrong
- bypass GPIO map in UARTClass::begin and use true k210 pin number in this class