### PR TITLE
[suggestion] : having a flip function with horizontal and vertical

### DIFF
--- a/libraries/Camera/src/Camera.h
+++ b/libraries/Camera/src/Camera.h
@@ -78,6 +78,7 @@ public:
     virtual uint8_t* getRGB888(){ return nullptr; };
     virtual void setRotation(uint8_t rotation) = 0;
     virtual void setInvert(bool invert) = 0;
+    virtual void flip(bool horiz, bool vert);
 
 
     virtual int width(){ return _width; }

--- a/libraries/Sipeed_OV2640/src/Sipeed_OV2640.cpp
+++ b/libraries/Sipeed_OV2640/src/Sipeed_OV2640.cpp
@@ -1488,6 +1488,38 @@ int Sipeed_OV2640::ov2640_set_vflip(int enable)
     return ret;
 }
 
+
+int Sipeed_OV2640::ov2640_set_flip(bool horiz, bool vert) 
+{
+	uint8_t reg;
+	int ret = cambus_readb(_slaveAddr, BANK_SEL, &reg);
+	ret |= cambus_writeb(_slaveAddr, BANK_SEL, reg | BANK_SEL_SENSOR);
+	ret |= cambus_readb(_slaveAddr, REG04, &reg);
+
+	if (horiz) {
+		reg |= REG04_HFLIP_IMG;
+		reg |= REG04_HREF_EN;
+	} 
+	else {
+		reg &= ~REG04_HFLIP_IMG;
+		reg &= ~REG04_HREF_EN;
+	}
+
+	if (vert) {
+		reg |= REG04_VFLIP_IMG;
+		reg |= REG04_VREF_EN;
+	} 
+	else {
+		reg &= ~REG04_VFLIP_IMG;
+		reg &= ~REG04_VREF_EN;
+	}
+
+	ret |= cambus_writeb(_slaveAddr, REG04, reg);
+
+	return ret;
+}
+
+
 int Sipeed_OV2640::reverse_u32pixel(uint32_t* addr,uint32_t length)
 {
   if(NULL == addr)
@@ -1522,3 +1554,6 @@ int Sipeed_OV2640::sensor_snapshot( )
     return 0;
 }
 
+int Sipeed_OV2640::flip( bool horiz, bool vert ) {
+	return ov2640_set_flip(horiz, vert);
+}

--- a/libraries/Sipeed_OV2640/src/Sipeed_OV2640.h
+++ b/libraries/Sipeed_OV2640/src/Sipeed_OV2640.h
@@ -56,6 +56,8 @@ public:
     virtual uint8_t* getRGB888(){ return _aiBuffer; };
     virtual void setRotation(uint8_t rotation);
     virtual void setInvert(bool invert);
+    void flip(bool horiz, bool vert);
+
 
 private:
     uint8_t* _dataBuffer;    // put RGB565 data
@@ -103,6 +105,8 @@ private:
     int ov2640_get_rgb_gain_db(float *r_gain_db, float *g_gain_db, float *b_gain_db);
     int ov2640_set_hmirror(int enable);
     int ov2640_set_vflip(int enable);
+    int ov2640_set_flip(bool horiz, bool vert);
+
     int sensor_snapshot( );
     int reverse_u32pixel(uint32_t* addr,uint32_t length);
 


### PR DESCRIPTION
if it is welcome I can make requested changes.
in my usage I prefer this function over ov2640_set_hmirror / ov2640_set_vflip
it is easier to understand and it also sets the right regs so pixel order is kept intact. ```REG04_VREF_EN / REG04_HREF_EN ```
