### PR TITLE
Fix color inversion inside a buffer

### DIFF
--- a/libraries/Sipeed_OV2640/src/Sipeed_OV2640.cpp
+++ b/libraries/Sipeed_OV2640/src/Sipeed_OV2640.cpp
@@ -537,7 +537,7 @@ static const uint8_t yuv422_regs[][2] = {
         { BANK_SEL, BANK_SEL_DSP },
         { RESET,   RESET_DVP},
         { 0xD7,     0x01 },
-        { IMAGE_MODE, IMAGE_MODE_YUV422 },
+        { IMAGE_MODE, IMAGE_MODE_YUV422 | 0b00000001 },
         { 0xE1,     0x67 },
         { RESET,    0x00 },
         {0, 0},

--- a/libraries/Sipeed_OV2640/src/Sipeed_OV2640.cpp
+++ b/libraries/Sipeed_OV2640/src/Sipeed_OV2640.cpp
@@ -1530,8 +1530,8 @@ int Sipeed_OV2640::reverse_u32pixel(uint32_t* addr,uint32_t length)
   for(;addr<pend;addr++)
   {
 	  data = *(addr);
-	  *(addr) = ((data & 0x000000FF) << 24) | ((data & 0x0000FF00) << 8) | 
-                ((data & 0x00FF0000) >> 8) | ((data & 0xFF000000) >> 24) ;
+      *(addr) = ((data & 0x0000FFFF) << 16) | ((data & 0xFFFF0000) >> 16);
+
   }  //1.7ms
   
   

--- a/libraries/Sipeed_ST7789/src/lcd.c
+++ b/libraries/Sipeed_ST7789/src/lcd.c
@@ -213,8 +213,6 @@ void lcd_draw_rectangle(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint
     tft_write_word(data_buf, ((y2 - y1 + 1) * width + 1) / 2);
 }
 
-#define SWAP_16(x) ((x >> 8 & 0xff) | (x << 8))
-
 void lcd_draw_picture(uint16_t x1, uint16_t y1, uint16_t width, uint16_t height, uint16_t *ptr)
 {
     uint32_t i;
@@ -222,8 +220,8 @@ void lcd_draw_picture(uint16_t x1, uint16_t y1, uint16_t width, uint16_t height,
     lcd_set_area(x1, y1, x1 + width - 1, y1 + height - 1);
     for (i = 0; i < LCD_MAX_PIXELS; i += 2)
     {
-        g_lcd_display_buff[i] = SWAP_16(*(p + 1));
-        g_lcd_display_buff[i + 1] = SWAP_16(*(p));
+        g_lcd_display_buff[i] = *(p + 1);
+        g_lcd_display_buff[i + 1] = *(p);
         p += 2;
     }
     tft_write_word((uint32_t*)g_lcd_display_buff, width * height / 2);


### PR DESCRIPTION
Maixduino use to handle flipped colors inside a image buffer. By removing a byte swap from lcd we are able now to handle colors correctly for objects and image buffer.
it is now possible to make a gradient from black to white inside one image with the changes in this PR.

closes
https://github.com/sipeed/Maixduino/issues/141
closes
https://github.com/sipeed/Maixduino/issues/138
